### PR TITLE
Task/64 buddies display on dashboard

### DIFF
--- a/frontend/src/components/people/PersonBadge/PersonBadge.tsx
+++ b/frontend/src/components/people/PersonBadge/PersonBadge.tsx
@@ -2,6 +2,7 @@ import { Group, Text } from "@mantine/core";
 import type { Person } from "../../../api/Api";
 import classes from "./PersonBadge.module.css";
 import Avatar from "../Avatar";
+import Anchor from "../../Anchor";
 
 interface PersonBadgeProps {
   person: Person | null;
@@ -10,26 +11,35 @@ interface PersonBadgeProps {
   variant?: "default" | "transparent";
   textOverride?: string;
   noText?: boolean;
+  link?: boolean;
 }
 
-export default function PersonBadge({ person, me, highlight, textOverride, noText, variant = "default" }: PersonBadgeProps) {
+export default function PersonBadge({ person, me, highlight, textOverride, noText, variant = "default", link = false }: PersonBadgeProps) {
   if (!person) {
     return null;
   }
 
-  const groupClasses = [];
-  if (variant === "default") groupClasses.push(classes.default);
-  if (me) groupClasses.push(classes.me);
-  if (highlight) groupClasses.push(classes.highlighted);
+  const badgeClasses = [];
+  if (variant === "default") badgeClasses.push(classes.default);
+  if (me) badgeClasses.push(classes.me);
+  if (highlight) badgeClasses.push(classes.highlighted);
 
-  return (
-    <Group gap="xs" className={groupClasses.join(" ")} wrap="nowrap">
+  const wrapElement = (children: React.ReactNode) => {
+    if (link) {
+      return <Anchor href={`/people/${person.id}`}>{children}</Anchor>;
+    } else {
+      return children;
+    }
+  };
+
+  return wrapElement(
+    <Group gap="xs" className={badgeClasses.join(" ")} wrap="nowrap">
       <Avatar avatarId={person.avatar_id ?? person.id} />
       {!noText && (
-        <Text fz="sm" fw={500}>
+        <Text fz="sm" fw={500} span>
           {textOverride ?? person.display_name}
         </Text>
       )}
-    </Group>
+    </Group>,
   );
 }

--- a/frontend/src/contexts/peer_roles/components/YourEnrollment.tsx
+++ b/frontend/src/contexts/peer_roles/components/YourEnrollment.tsx
@@ -1,0 +1,28 @@
+import { Group, Text } from "@mantine/core";
+import type { PeerEnrollment, PeerRole } from "../../../api/Api";
+import { PersonBadge } from "../../../components";
+import { mapPeopleIds, type PeopleObjectMap } from "../../../store/people";
+
+interface YourEnrollmentProps {
+  enrollment: PeerEnrollment;
+  role: PeerRole;
+  personId: number;
+  people: PeopleObjectMap;
+}
+
+export default function YourEnrollment({ enrollment, role, personId, people }: YourEnrollmentProps) {
+  const rolePersonIds = [enrollment.person_id, enrollment.peer_id];
+  const rolePeople = mapPeopleIds(rolePersonIds, people);
+  const otherPeople = rolePeople.filter((p) => p.id !== personId);
+
+  return (
+    <Group>
+      <Text>You are {role.name} with </Text>
+      <Group>
+        {otherPeople.map((person) => (
+          <PersonBadge key={person.id} person={person} link />
+        ))}
+      </Group>
+    </Group>
+  );
+}

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -17,7 +17,8 @@ import { useCurrentInterval } from "../../store/current_interval";
 import { forPerson } from "../../store/current_interval/crew_involvements";
 import { circleInvolvementforCircleAndPerson } from "../../store/current_interval/circle_involvements";
 import WithIntervalData from "../intervals/WithIntervalData";
-import { involvingPerson } from "../../store/current_interval/peer_enrollments";
+import { initiatingFromPerson, involvingPerson } from "../../store/current_interval/peer_enrollments";
+import YourEnrollment from "../../contexts/peer_roles/components/YourEnrollment";
 
 function ParticipationBadge({ involvement }: { involvement: CircleInvolvement | null }) {
   if (!involvement) return <Badge color="gray">No intention</Badge>;
@@ -151,19 +152,24 @@ function MyEvents({ personId }: { personId: number }) {
 
 function MyPeerRoles({ personId }: { personId: number }) {
   const allEnrollments = useAppSelector((state) => state.currentInterval?.peer_enrollments || []);
-  const myEnrollments = involvingPerson(allEnrollments, personId);
+  const roles = useAppSelector((state) => state.peerRoles);
+  const people = useAppSelector((state) => state.people);
+
+  const myEnrollments = initiatingFromPerson(allEnrollments, personId);
 
   if (myEnrollments.length === 0) return null;
 
   return (
     <Stack gap="md">
       <Title order={2}>My Peer Roles</Title>
-      {myEnrollments.map((enrollment: PeerEnrollment) => (
-        <Card key={enrollment.id} withBorder>
-          <Text>You are enrolled as a peer for person #{enrollment.peer_id}.</Text>
-        </Card>
-      ))}
-      <Text>Peer roles are not yet implemented.</Text>
+      <Stack>
+        {myEnrollments.map((enrollment: PeerEnrollment) => {
+          const role = roles[enrollment.peer_role_id];
+          if (!role) return null;
+
+          return <YourEnrollment key={enrollment.id} enrollment={enrollment} role={role} personId={personId} people={people} />;
+        })}
+      </Stack>
     </Stack>
   );
 }

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, Container, Title, Stack, Text, Badge, Group, Collapse } from "@mantine/core";
 import { useNavigate } from "react-router-dom";
 import { useAppSelector } from "../../store";
-import { AttendanceIntention, type CalendarEvent, type CircleInvolvement, type CrewInvolvement, type Interval } from "../../api/Api";
+import { AttendanceIntention, type CalendarEvent, type CircleInvolvement, type CrewInvolvement, type Interval, type PeerEnrollment } from "../../api/Api";
 import DateText from "../../components/DateText";
 import classes from "./Dashboard.module.css";
 import { CrewsList, LinksStack } from "../../components";
@@ -17,6 +17,7 @@ import { useCurrentInterval } from "../../store/current_interval";
 import { forPerson } from "../../store/current_interval/crew_involvements";
 import { circleInvolvementforCircleAndPerson } from "../../store/current_interval/circle_involvements";
 import WithIntervalData from "../intervals/WithIntervalData";
+import { involvingPerson } from "../../store/current_interval/peer_enrollments";
 
 function ParticipationBadge({ involvement }: { involvement: CircleInvolvement | null }) {
   if (!involvement) return <Badge color="gray">No intention</Badge>;
@@ -121,8 +122,8 @@ function SubscribeDetails({ calendarToken }: { calendarToken: string }) {
   );
 }
 
-function MyEvents() {
-  const events = useAppSelector((state) => myUpcomingEvents(state.events, state.me?.person_id));
+function MyEvents({ personId }: { personId: number }) {
+  const events = useAppSelector((state) => myUpcomingEvents(state.events, personId));
   const [opened, { toggle }] = useDisclosure(false);
   const calendarToken = useAppSelector((state) => state.me?.calendar_token);
 
@@ -144,6 +145,25 @@ function MyEvents() {
         )}
         <EventsList events={events} noDataMessage="No upcoming events found" />
       </Stack>
+    </Stack>
+  );
+}
+
+function MyPeerRoles({ personId }: { personId: number }) {
+  const allEnrollments = useAppSelector((state) => state.currentInterval?.peer_enrollments || []);
+  const myEnrollments = involvingPerson(allEnrollments, personId);
+
+  if (myEnrollments.length === 0) return null;
+
+  return (
+    <Stack gap="md">
+      <Title order={2}>My Peer Roles</Title>
+      {myEnrollments.map((enrollment: PeerEnrollment) => (
+        <Card key={enrollment.id} withBorder>
+          <Text>You are enrolled as a peer for person #{enrollment.peer_id}.</Text>
+        </Card>
+      ))}
+      <Text>Peer roles are not yet implemented.</Text>
     </Stack>
   );
 }
@@ -183,7 +203,8 @@ export default function Dashboard() {
             }}
           </WithIntervalData>
         </Stack>
-        <MyEvents />
+        <MyEvents personId={personId} />
+        <MyPeerRoles personId={personId} />
         {myCurrentCrewInvolvements && <MyCrews personId={myData.person_id} myInvolvements={myCurrentCrewInvolvements} />}
         <Stack gap="md">
           <Title order={2}>Resources</Title>

--- a/frontend/src/store/current_interval/peer_enrollments.ts
+++ b/frontend/src/store/current_interval/peer_enrollments.ts
@@ -3,3 +3,7 @@ import type { PeerEnrollment } from "../../api/Api";
 export function involvingPerson(enrollments: PeerEnrollment[], personId: number): PeerEnrollment[] {
   return enrollments.filter((enrollment) => enrollment.person_id === personId || enrollment.peer_id === personId);
 }
+
+export function initiatingFromPerson(enrollments: PeerEnrollment[], personId: number): PeerEnrollment[] {
+  return enrollments.filter((enrollment) => enrollment.person_id === personId);
+}

--- a/frontend/src/store/current_interval/peer_enrollments.ts
+++ b/frontend/src/store/current_interval/peer_enrollments.ts
@@ -1,0 +1,5 @@
+import type { PeerEnrollment } from "../../api/Api";
+
+export function involvingPerson(enrollments: PeerEnrollment[], personId: number): PeerEnrollment[] {
+  return enrollments.filter((enrollment) => enrollment.person_id === personId || enrollment.peer_id === personId);
+}

--- a/frontend/src/store/people.ts
+++ b/frontend/src/store/people.ts
@@ -7,6 +7,10 @@ export interface PeopleObjectMap {
 
 export type PeopleState = PeopleObjectMap;
 
+export function mapPeopleIds(ids: number[], people: PeopleObjectMap): Person[] {
+  return ids.map((id) => people[id]);
+}
+
 const peopleSlice = createSlice({
   name: "people",
   initialState: {} as PeopleState,


### PR DESCRIPTION
Currently a 3 person group of buddies will just display two lines.

Also, the current approach wont work well for supporters yet, as it wont show the person supporting you.

<img width="673" height="670" alt="image" src="https://github.com/user-attachments/assets/dfb49c14-6014-4400-b770-2865e7d451ad" />

