### PR TITLE
Task/58 ability to create peer roles

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,6 +50,7 @@ import "@mantine/dates/styles.css";
 import "@mantine/notifications/styles.css";
 import { Circles, EditCircle, NewCircle } from "./contexts/circles";
 import { PeerRoles } from "./contexts/peer_roles";
+//import NewRole from "./contexts/peer_roles/pages/NewRole";
 
 function withStore(
   func: (store: AppStore) => any,
@@ -130,6 +131,10 @@ const router = createBrowserRouter([
       {
         path: "peer_roles",
         element: <PeerRoles />,
+      },
+      {
+        path: "peer_roles/new",
+        element: <NewRole />,
       },
       {
         path: "crews",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -132,10 +132,10 @@ const router = createBrowserRouter([
         path: "peer_roles",
         element: <PeerRoles />,
       },
-      {
-        path: "peer_roles/new",
-        element: <NewRole />,
-      },
+      //{
+      //  path: "peer_roles/new",
+      //  element: <NewRole />,
+      //}, //TODO
       {
         path: "crews",
         element: <Crews />,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,6 +50,7 @@ import "@mantine/dates/styles.css";
 import "@mantine/notifications/styles.css";
 import { Circles, EditCircle, NewCircle } from "./contexts/circles";
 import { PeerRoles } from "./contexts/peer_roles";
+import NewRole from "./contexts/peer_roles/pages/NewRole";
 //import NewRole from "./contexts/peer_roles/pages/NewRole";
 
 function withStore(
@@ -132,10 +133,10 @@ const router = createBrowserRouter([
         path: "peer_roles",
         element: <PeerRoles />,
       },
-      //{
-      //  path: "peer_roles/new",
-      //  element: <NewRole />,
-      //}, //TODO
+      {
+        path: "peer_roles/new",
+        element: <NewRole />,
+      },
       {
         path: "crews",
         element: <Crews />,

--- a/frontend/src/api/Api.ts
+++ b/frontend/src/api/Api.ts
@@ -89,7 +89,7 @@ export type AppEvent =
   | {
       CirclesEvent: CirclesEvent;
     };
-
+    
 export interface CalendarEvent {
   attendances?: CalendarEventAttendance[] | null;
   description: string;
@@ -399,6 +399,8 @@ export interface PeerRole {
   /** @format int64 */
   project_id: number;
 }
+
+//export interface NewRole {} //TODO: update details
 
 export type PeopleEvent = {
   PersonUpdated: Person;
@@ -1163,5 +1165,21 @@ export class Api<
         method: "GET",
         ...params,
       }),
+
+      ///**
+      // * No description
+      // *
+      // * @name CreateNewRole
+      // * @request POST:/api/peer_roles/new
+      // */
+      //createNewRole: (data: NewRole, params: RequestParams = {}) =>
+      //  this.request<AppEvent[], any>({
+      //    path: `/api/peer_roles/new`,
+      //    method: "POST",
+      //    body: data,
+      //    type: ContentType.Json,
+      //    format: "json",
+      //    ...params,
+      //  }), //TODO: check
   };
 }

--- a/frontend/src/contexts/events/pages/NewEvent.tsx
+++ b/frontend/src/contexts/events/pages/NewEvent.tsx
@@ -26,9 +26,13 @@ export default function NewEvent() {
       <Stack mb="md">
         <Title order={1}>New Event</Title>
 
-        {eventTemplates.length === 0 && <p>No event templates available. Please create one first.</p>}
+        {eventTemplates.length === 0 && (
+          <p>No event templates available. Please create one first.</p>
+        )}
 
-        {eventTemplates.length > 0 && <EventForm onSubmit={handleSubmit} eventTemplates={eventTemplates} />}
+        {eventTemplates.length > 0 && (
+          <EventForm onSubmit={handleSubmit} eventTemplates={eventTemplates} />
+        )}
       </Stack>
     </Container>
   );

--- a/frontend/src/contexts/peer_roles/components/PeerRolesTable.tsx
+++ b/frontend/src/contexts/peer_roles/components/PeerRolesTable.tsx
@@ -1,20 +1,15 @@
 import { Table } from "@mantine/core";
+import type { PeerRole } from "../../../api/Api";
 
 interface PeerRolesTableProps {
   peerRoles: PeerRole[];
-}
-
-interface PeerRole {
-  role: number;
-  name: string;
-  summary: string;
 }
 
 export default function PeerRolesTable({ peerRoles }: PeerRolesTableProps) {
   const rows = peerRoles.map((role) => (
     <Table.Tr key={role.name}>
       <Table.Td>{role.name}</Table.Td>
-      <Table.Td>{role.summary}</Table.Td>
+      {/*<Table.Td>{role.summary}</Table.Td>*/}
       <Table.Td>edit</Table.Td>
     </Table.Tr>
   ));
@@ -24,7 +19,7 @@ export default function PeerRolesTable({ peerRoles }: PeerRolesTableProps) {
       <Table.Thead>
         <Table.Tr>
           <Table.Th>Role</Table.Th>
-          <Table.Th>Summary</Table.Th>
+          {/*<Table.Th>Summary</Table.Th>*/}
           <Table.Th>Actions</Table.Th>
         </Table.Tr>
       </Table.Thead>

--- a/frontend/src/contexts/peer_roles/components/RoleForm.tsx
+++ b/frontend/src/contexts/peer_roles/components/RoleForm.tsx
@@ -75,7 +75,7 @@ export default function NewRoleForm({ value, peerRoles, submitText, onSubmit }: 
               key={form.key("peer_roles_table_id")}
               {...form.getInputProps("peer_roles_table_id")}
             />
-          )} // Todo: investigate peerRoles and form errors 
+          )} //TODO resolve errors
 
           <TextInput
             label="Name"

--- a/frontend/src/contexts/peer_roles/components/RoleForm.tsx
+++ b/frontend/src/contexts/peer_roles/components/RoleForm.tsx
@@ -1,0 +1,104 @@
+import { useForm } from "@mantine/form";
+import { Button, Select, Stack, Textarea, TextInput } from "@mantine/core";
+import { LinksInput } from "../../../components";
+
+interface RoleFormData {
+  id: number;
+  role_table_id: number | null;
+  name: string | null;
+  summary: string;
+  action: string;
+}
+
+interface PeerRolesFormProps {
+  value?: NewRole | null;
+  peerRoles?: PeerRolesTable[];
+  submitText?: string;
+  onSubmit: (data: NewRole) => Promise<void>;
+}
+
+// Todo: add NewRole and PeerRolesTable to Api.ts
+
+const defaultRole: RoleFormData = {
+  id: -1,
+  role_table_id: null,
+  name: "",
+  summary: "",
+  action: "",
+};
+
+function prepareNewRole(data: RoleFormData): NewRole | null {
+  if (!data.role_table_id || !data.name) {
+    return null;
+  }
+
+  return {
+    ...data,
+    role_table_id: parseInt(data.role_table_id.toString(), 10),
+    name: data.name,
+  };
+}
+
+export default function NewRoleForm({ value, peerRoles, submitText, onSubmit }: PeerRolesFormProps) {
+  const form = useForm<RoleFormData>({
+    mode: "controlled",
+    initialValues: {
+      ...defaultRole,
+      ...value,
+    },
+    validate: {
+      role_table_id: (value) => (value ? null : "Peer role ID is required"),
+      name: (value) => (value && value.trim().length > 0 ? null : "Name is required"),
+        }
+        return null;
+      },
+  });  // Todo: investigate useForm error
+
+  const onSubmitFormData = (data: RoleFormData) => {
+    const preparedRole = prepareNewRole(data);
+    if (preparedRole) {
+      onSubmit(preparedRole);
+    } else {
+      console.error("Failed to prepare new role from form data:", data);
+    }
+  };  // Todo: investigate OnSubmit error
+  
+    return (
+      <form onSubmit={form.onSubmit(onSubmitFormData, (errors) => console.log("Form submission errors:", errors))}>
+        <Stack gap="lg">
+          <Stack gap="md">
+            {peerRoles && peerRoles.length >= 0 && (
+              <Select
+                label="Event Template"
+                description=""
+                placeholder="Pick value"
+                data={peerRoles.map((template) => ({ label: template.name, value: template.id.toString() }))}
+                key={form.key("peer_roles_table_id")}
+                {...form.getInputProps("peer_roles_table_id")}
+              />
+            )} // Todo: investigate peerRoles and form errors
+  
+            <TextInput
+              label="Name"
+              description="The name of this role."
+              placeholder="Care Supporter, Participation Buddy, etc"
+              withAsterisk
+              {...form.getInputProps("name")}
+            />
+    
+            <TextInput
+              label="Summary"
+              description="A short summary of the role to provide more context."
+              placeholder="A brief summary of the responsibilities associated with the role"
+              {...form.getInputProps("summary")}
+            />
+
+          </Stack>
+          <Button type="submit" loading={form.submitting}>
+            {submitText || "Create event"}
+          </Button>
+        </Stack>
+      </form>
+    );
+  }
+

--- a/frontend/src/contexts/peer_roles/components/RoleForm.tsx
+++ b/frontend/src/contexts/peer_roles/components/RoleForm.tsx
@@ -13,8 +13,6 @@ interface PeerRolesFormProps {
   onSubmit: (data: RoleFormData) => Promise<void>;
 }
 
-// Todo: add NewRole and PeerRolesTable to Api.ts
-
 const defaultRole: RoleFormData = {
   id: -1,
   name: "",

--- a/frontend/src/contexts/peer_roles/components/RoleForm.tsx
+++ b/frontend/src/contexts/peer_roles/components/RoleForm.tsx
@@ -1,44 +1,31 @@
 import { useForm } from "@mantine/form";
-import { Button, Select, Stack, Textarea, TextInput } from "@mantine/core";
+import { Button, Stack, TextInput } from "@mantine/core";
 
-interface RoleFormData {
+export interface RoleFormData {
   id: number;
-  role_table_id: number | null;
   name: string | null;
   summary: string;
-  action: string;
 }
 
 interface PeerRolesFormProps {
-  value?: NewRole | null; //Todo: add NewRole to Api.ts (see CalanderEvent for model)
-  peerRoles?: PeerRolesTable[]; //Todo: add PeerRolesTable to Api.ts (see example EventsTemplate)
+  value?: RoleFormData | null; //Todo: add NewRole to Api.ts (see CalanderEvent for model)
   submitText?: string;
-  onSubmit: (data: NewRole) => Promise<void>;
+  onSubmit: (data: RoleFormData) => Promise<void>;
 }
 
-// Todo: add NewRole and PeerRolesTable to Api.ts 
+// Todo: add NewRole and PeerRolesTable to Api.ts
 
 const defaultRole: RoleFormData = {
   id: -1,
-  role_table_id: null,
   name: "",
   summary: "",
-  action: "",
 };
 
-function prepareNewRole(data: RoleFormData): NewRole | null {
-  if (!data.role_table_id || !data.name) {
-    return null;
-  }
-
-  return {
-    ...data,
-    role_table_id: parseInt(data.role_table_id.toString(), 10),
-    name: data.name,
-  };
-}
-
-export default function NewRoleForm({ value, peerRoles, submitText, onSubmit }: PeerRolesFormProps) {
+export default function NewRoleForm({
+  value,
+  submitText,
+  onSubmit,
+}: PeerRolesFormProps) {
   const form = useForm<RoleFormData>({
     mode: "controlled",
     initialValues: {
@@ -46,37 +33,19 @@ export default function NewRoleForm({ value, peerRoles, submitText, onSubmit }: 
       ...value,
     },
     validate: {
-      role_table_id: (value) => (value ? null : "Peer role ID is required"),
-      name: (value) => (value && value.trim().length > 0 ? null : "Name is required"),
-        }
-        return null;
-      },
-  );  // Todo: investigate useForm error
+      name: (value) =>
+        value && value.trim().length > 0 ? null : "Name is required",
+    },
+  });
 
-  const onSubmitFormData = (data: RoleFormData) => {
-    const preparedRole = prepareNewRole(data);
-    if (preparedRole) {
-      onSubmit(preparedRole);
-    } else {
-      console.error("Failed to prepare new role from form data:", data);
-    }
-  };  
-  
   return (
-    <form onSubmit={form.onSubmit(onSubmitFormData, (errors) => console.log("Form submission errors:", errors))}>
+    <form
+      onSubmit={form.onSubmit(onSubmit, (errors) =>
+        console.log("Form submission errors:", errors),
+      )}
+    >
       <Stack gap="lg">
         <Stack gap="md">
-          {peerRoles && peerRoles.length >= 0 && (
-            <Select
-              label="Event Template"
-              description=""
-              placeholder="Pick value"
-              data={peerRoles.map((template) => ({ label: template.name, value: template.id.toString() }))}
-              key={form.key("peer_roles_table_id")}
-              {...form.getInputProps("peer_roles_table_id")}
-            />
-          )} //TODO resolve errors
-
           <TextInput
             label="Name"
             description="The name of this role."
@@ -84,20 +53,17 @@ export default function NewRoleForm({ value, peerRoles, submitText, onSubmit }: 
             withAsterisk
             {...form.getInputProps("name")}
           />
-  
           <TextInput
             label="Summary"
             description="A short summary of the role to provide more context."
             placeholder="A brief summary of the responsibilities associated with the role"
             {...form.getInputProps("summary")}
           />
-
         </Stack>
         <Button type="submit" loading={form.submitting}>
-          {submitText || "Create event"}
+          {submitText || "Create role"}
         </Button>
       </Stack>
     </form>
   );
 }
-

--- a/frontend/src/contexts/peer_roles/components/RoleForm.tsx
+++ b/frontend/src/contexts/peer_roles/components/RoleForm.tsx
@@ -1,6 +1,5 @@
 import { useForm } from "@mantine/form";
 import { Button, Select, Stack, Textarea, TextInput } from "@mantine/core";
-import { LinksInput } from "../../../components";
 
 interface RoleFormData {
   id: number;
@@ -11,13 +10,13 @@ interface RoleFormData {
 }
 
 interface PeerRolesFormProps {
-  value?: NewRole | null;
-  peerRoles?: PeerRolesTable[];
+  value?: NewRole | null; //Todo: add NewRole to Api.ts (see CalanderEvent for model)
+  peerRoles?: PeerRolesTable[]; //Todo: add PeerRolesTable to Api.ts (see example EventsTemplate)
   submitText?: string;
   onSubmit: (data: NewRole) => Promise<void>;
 }
 
-// Todo: add NewRole and PeerRolesTable to Api.ts
+// Todo: add NewRole and PeerRolesTable to Api.ts 
 
 const defaultRole: RoleFormData = {
   id: -1,

--- a/frontend/src/contexts/peer_roles/components/RoleForm.tsx
+++ b/frontend/src/contexts/peer_roles/components/RoleForm.tsx
@@ -60,7 +60,7 @@ export default function NewRoleForm({ value, peerRoles, submitText, onSubmit }: 
     } else {
       console.error("Failed to prepare new role from form data:", data);
     }
-  };  // Todo: investigate UseForm error
+  };  
   
   return (
     <form onSubmit={form.onSubmit(onSubmitFormData, (errors) => console.log("Form submission errors:", errors))}>

--- a/frontend/src/contexts/peer_roles/components/RoleForm.tsx
+++ b/frontend/src/contexts/peer_roles/components/RoleForm.tsx
@@ -51,7 +51,7 @@ export default function NewRoleForm({ value, peerRoles, submitText, onSubmit }: 
         }
         return null;
       },
-  });  // Todo: investigate useForm error
+  );  // Todo: investigate useForm error
 
   const onSubmitFormData = (data: RoleFormData) => {
     const preparedRole = prepareNewRole(data);
@@ -60,44 +60,44 @@ export default function NewRoleForm({ value, peerRoles, submitText, onSubmit }: 
     } else {
       console.error("Failed to prepare new role from form data:", data);
     }
-  };  // Todo: investigate OnSubmit error
+  };  // Todo: investigate UseForm error
   
-    return (
-      <form onSubmit={form.onSubmit(onSubmitFormData, (errors) => console.log("Form submission errors:", errors))}>
-        <Stack gap="lg">
-          <Stack gap="md">
-            {peerRoles && peerRoles.length >= 0 && (
-              <Select
-                label="Event Template"
-                description=""
-                placeholder="Pick value"
-                data={peerRoles.map((template) => ({ label: template.name, value: template.id.toString() }))}
-                key={form.key("peer_roles_table_id")}
-                {...form.getInputProps("peer_roles_table_id")}
-              />
-            )} // Todo: investigate peerRoles and form errors
-  
-            <TextInput
-              label="Name"
-              description="The name of this role."
-              placeholder="Care Supporter, Participation Buddy, etc"
-              withAsterisk
-              {...form.getInputProps("name")}
+  return (
+    <form onSubmit={form.onSubmit(onSubmitFormData, (errors) => console.log("Form submission errors:", errors))}>
+      <Stack gap="lg">
+        <Stack gap="md">
+          {peerRoles && peerRoles.length >= 0 && (
+            <Select
+              label="Event Template"
+              description=""
+              placeholder="Pick value"
+              data={peerRoles.map((template) => ({ label: template.name, value: template.id.toString() }))}
+              key={form.key("peer_roles_table_id")}
+              {...form.getInputProps("peer_roles_table_id")}
             />
-    
-            <TextInput
-              label="Summary"
-              description="A short summary of the role to provide more context."
-              placeholder="A brief summary of the responsibilities associated with the role"
-              {...form.getInputProps("summary")}
-            />
+          )} // Todo: investigate peerRoles and form errors 
 
-          </Stack>
-          <Button type="submit" loading={form.submitting}>
-            {submitText || "Create event"}
-          </Button>
+          <TextInput
+            label="Name"
+            description="The name of this role."
+            placeholder="Care Supporter, Participation Buddy, etc"
+            withAsterisk
+            {...form.getInputProps("name")}
+          />
+  
+          <TextInput
+            label="Summary"
+            description="A short summary of the role to provide more context."
+            placeholder="A brief summary of the responsibilities associated with the role"
+            {...form.getInputProps("summary")}
+          />
+
         </Stack>
-      </form>
-    );
-  }
+        <Button type="submit" loading={form.submitting}>
+          {submitText || "Create event"}
+        </Button>
+      </Stack>
+    </form>
+  );
+}
 

--- a/frontend/src/contexts/peer_roles/pages/NewRole.tsx
+++ b/frontend/src/contexts/peer_roles/pages/NewRole.tsx
@@ -1,38 +1,27 @@
 import { Container, Title, Stack } from "@mantine/core";
-import RoleForm from "../components/RoleForm";
-import type { NewRole } from "../../../api/Api"; //Todo: check NewRole in Api.ts (see CalanderEvent for model)
-import { handleAppEvents, useAppSelector } from "../../../store";
-import { getApi } from "../../../api";
-import { useNavigate } from "react-router-dom";
+import RoleForm, { type RoleFormData } from "../components/RoleForm";
 
 export default function NewRole() {
-  const peerRoles = useAppSelector((state) => state.peerRoles);
-  const navigate = useNavigate();
+  //const navigate = useNavigate();
 
-  const handleSubmit = async (data: NewRole): Promise<void> => {
-    return getApi()
-      .api.createNewRole(data) // Todo: check createNewROle to Api.ts (see createCalendarEvent for model)
-      .then((response) => {
-        handleAppEvents(response.data);
-        navigate("/peer_roles");
-      })
-      .catch((error) => {
-        console.error("Error creating role:", error);
-      });
+  const handleSubmit = async (data: RoleFormData): Promise<void> => {
+    console.log("handling form result", data);
+    //return getApi()
+    //  .api.createNewRole(data) // Todo: check createNewROle to Api.ts (see createCalendarEvent for model)
+    //  .then((response) => {
+    //    handleAppEvents(response.data);
+    //    navigate("/peer_roles");
+    //  })
+    //  .catch((error) => {
+    //    console.error("Error creating role:", error);
+    //  });
   }; //
 
   return (
     <Container>
       <Stack mb="md">
         <Title order={1}>New Role</Title>
-
-        {peerRoles.length === 0 && (
-          <p>No event roles available. Please create one first.</p>
-        )}
-
-        {peerRoles.length > 0 && (
-          <RoleForm onSubmit={handleSubmit} peerRoles={peerRoles} />
-        )}
+        <RoleForm onSubmit={handleSubmit} />
       </Stack>
     </Container>
   );

--- a/frontend/src/contexts/peer_roles/pages/NewRole.tsx
+++ b/frontend/src/contexts/peer_roles/pages/NewRole.tsx
@@ -11,7 +11,7 @@ export default function NewRole() {
 
   const handleSubmit = async (data: NewRole): Promise<void> => {
     return getApi()
-      .api.createNewRole(data) // Todo: add createNewROle to Api.ts (see createCalendarEvent for model)
+      .api.createNewRole(data) // Todo: check createNewROle to Api.ts (see createCalendarEvent for model)
       .then((response) => {
         handleAppEvents(response.data);
         navigate("/peer_roles");

--- a/frontend/src/contexts/peer_roles/pages/NewRole.tsx
+++ b/frontend/src/contexts/peer_roles/pages/NewRole.tsx
@@ -15,7 +15,7 @@ export default function NewRole() {
     //  .catch((error) => {
     //    console.error("Error creating role:", error);
     //  });
-  }; // This can be used once the api has been set up
+  }; // These lines can replace the console.log line once the createNewRol api endpoint has been set up
 
   return (
     <Container>

--- a/frontend/src/contexts/peer_roles/pages/NewRole.tsx
+++ b/frontend/src/contexts/peer_roles/pages/NewRole.tsx
@@ -1,22 +1,25 @@
-import PeerRolesTable from "../components/PeerRolesTable";
+import { Container, Title, Stack } from "@mantine/core";
 import RoleForm from "../components/RoleForm";
+import type { NewRole } from "../../../api/Api"; //Todo: add NewRole to Api.ts (see CalanderEvent for model)
+import { handleAppEvents, useAppSelector } from "../../../store";
+import { getApi } from "../../../api";
+import { useNavigate } from "react-router-dom";
 
 export default function NewRole() {
-  const peerRoles = PeerRolesTable;
+  const peerRoles = useAppSelector((state) => state.peerRoles);
+  const navigate = useNavigate();
 
-  //  const navigate = useNavigate();
-
-  //  const handleSubmit = async (data: CalendarEvent): Promise<void> => {
-  //    return getApi()
-  //      .api.createCalendarEvent(data)
-  //      .then((response) => {
-  //        handleAppEvents(response.data);
-  //        navigate("/events");
-  //      })
-  //      .catch((error) => {
-  //        console.error("Error creating event:", error);
-  //      });
-  //  };
+  const handleSubmit = async (data: NewRole): Promise<void> => {
+    return getApi()
+      .api.createNewRole(data) // Todo: add createNewROle to Api.ts (see createCalendarEvent for model)
+      .then((response) => {
+        handleAppEvents(response.data);
+        navigate("/peer_roles");
+      })
+      .catch((error) => {
+        console.error("Error creating role:", error);
+      });
+  };
 
   return (
     <Container>

--- a/frontend/src/contexts/peer_roles/pages/NewRole.tsx
+++ b/frontend/src/contexts/peer_roles/pages/NewRole.tsx
@@ -1,6 +1,6 @@
 import { Container, Title, Stack } from "@mantine/core";
 import RoleForm from "../components/RoleForm";
-import type { NewRole } from "../../../api/Api"; //Todo: add NewRole to Api.ts (see CalanderEvent for model)
+import type { NewRole } from "../../../api/Api"; //Todo: check NewRole in Api.ts (see CalanderEvent for model)
 import { handleAppEvents, useAppSelector } from "../../../store";
 import { getApi } from "../../../api";
 import { useNavigate } from "react-router-dom";
@@ -19,7 +19,7 @@ export default function NewRole() {
       .catch((error) => {
         console.error("Error creating role:", error);
       });
-  };
+  }; //
 
   return (
     <Container>

--- a/frontend/src/contexts/peer_roles/pages/NewRole.tsx
+++ b/frontend/src/contexts/peer_roles/pages/NewRole.tsx
@@ -7,7 +7,7 @@ export default function NewRole() {
   const handleSubmit = async (data: RoleFormData): Promise<void> => {
     console.log("handling form result", data);
     //return getApi()
-    //  .api.createNewRole(data) // Todo: check createNewROle to Api.ts (see createCalendarEvent for model)
+    //  .api.createNewRole(data)
     //  .then((response) => {
     //    handleAppEvents(response.data);
     //    navigate("/peer_roles");
@@ -15,7 +15,7 @@ export default function NewRole() {
     //  .catch((error) => {
     //    console.error("Error creating role:", error);
     //  });
-  }; //
+  }; // This can be used once the api has been set up
 
   return (
     <Container>

--- a/frontend/src/contexts/peer_roles/pages/NewRole.tsx
+++ b/frontend/src/contexts/peer_roles/pages/NewRole.tsx
@@ -1,0 +1,36 @@
+import PeerRolesTable from "../components/PeerRolesTable";
+import RoleForm from "../components/RoleForm";
+
+export default function NewRole() {
+  const peerRoles = PeerRolesTable;
+
+  //  const navigate = useNavigate();
+
+  //  const handleSubmit = async (data: CalendarEvent): Promise<void> => {
+  //    return getApi()
+  //      .api.createCalendarEvent(data)
+  //      .then((response) => {
+  //        handleAppEvents(response.data);
+  //        navigate("/events");
+  //      })
+  //      .catch((error) => {
+  //        console.error("Error creating event:", error);
+  //      });
+  //  };
+
+  return (
+    <Container>
+      <Stack mb="md">
+        <Title order={1}>New Role</Title>
+
+        {peerRoles.length === 0 && (
+          <p>No event roles available. Please create one first.</p>
+        )}
+
+        {peerRoles.length > 0 && (
+          <RoleForm onSubmit={handleSubmit} peerRoles={peerRoles} />
+        )}
+      </Stack>
+    </Container>
+  );
+}

--- a/frontend/src/contexts/peer_roles/pages/PeerRoles.tsx
+++ b/frontend/src/contexts/peer_roles/pages/PeerRoles.tsx
@@ -1,6 +1,7 @@
 import { Stack, Group, Title, ActionIcon } from "@mantine/core";
 import { IconPlus } from "@tabler/icons-react";
-import { Anchor } from "@mantine/core";
+//import { Anchor } from "@mantine/core";
+import { Anchor } from "../../../components";
 import PeerRolesTable from "../components/PeerRolesTable";
 
 export default function PeerRoles() {

--- a/frontend/src/contexts/peer_roles/pages/PeerRoles.tsx
+++ b/frontend/src/contexts/peer_roles/pages/PeerRoles.tsx
@@ -2,29 +2,30 @@ import { Stack, Group, Title, ActionIcon } from "@mantine/core";
 import { IconPlus } from "@tabler/icons-react";
 import { Anchor } from "../../../components";
 import PeerRolesTable from "../components/PeerRolesTable";
+import { useAppSelector } from "../../../store";
 
 export default function PeerRoles() {
-  //const peerRoles = useAppSelector((state) => state.peerRoles);
-  const dummyPeers = [
-    {
-      role: 1,
-      name: "Participation Buddy",
-      summary:
-        "Participation Buddies support each-other to communicate and meet our participation intentions in the project",
-    },
-    {
-      role: 2,
-      name: "Care Supporter",
-      summary:
-        "The role of Care Supporters is to offer a holding space to practice expressing our feelings and reflecting on our experiences without exposing ourselves to either judgement or rescue.",
-    },
-    {
-      role: 3,
-      name: "Accountability Supporter",
-      summary:
-        "The role of Accountability supporters is to offer gentle challenges to practice reflecting on alternative perspectives and holding ourselves accountable for how our actions impact others (without policing each others' behaviour).",
-    },
-  ];
+  const peerRoles = useAppSelector((state) => state.peerRoles);
+  //const dummyPeers = [
+  //  {
+  //    role: 1,
+  //    name: "Participation Buddy",
+  //    summary:
+  //      "Participation Buddies support each-other to communicate and meet our participation intentions in the project",
+  //  },
+  //  {
+  //    role: 2,
+  //    name: "Care Supporter",
+  //    summary:
+  //      "The role of Care Supporters is to offer a holding space to practice expressing our feelings and reflecting on our experiences without exposing ourselves to either judgement or rescue.",
+  //  },
+  //  {
+  //    role: 3,
+  //    name: "Accountability Supporter",
+  //    summary:
+  //      "The role of Accountability supporters is to offer gentle challenges to practice reflecting on alternative perspectives and holding ourselves accountable for how our actions impact others (without policing each others' behaviour).",
+  //  },
+  //];
 
   return (
     <Stack>
@@ -36,7 +37,7 @@ export default function PeerRoles() {
           </ActionIcon>
         </Anchor>
       </Group>
-      <PeerRolesTable peerRoles={dummyPeers} />
+      <PeerRolesTable peerRoles={Object.values(peerRoles)} />
     </Stack>
   );
 }

--- a/frontend/src/contexts/peer_roles/pages/PeerRoles.tsx
+++ b/frontend/src/contexts/peer_roles/pages/PeerRoles.tsx
@@ -4,6 +4,7 @@ import { Anchor } from "../../../components";
 import PeerRolesTable from "../components/PeerRolesTable";
 
 export default function PeerRoles() {
+  //const peerRoles = useAppSelector((state) => state.peerRoles);
   const dummyPeers = [
     {
       role: 1,

--- a/frontend/src/contexts/peer_roles/pages/PeerRoles.tsx
+++ b/frontend/src/contexts/peer_roles/pages/PeerRoles.tsx
@@ -1,6 +1,5 @@
 import { Stack, Group, Title, ActionIcon } from "@mantine/core";
 import { IconPlus } from "@tabler/icons-react";
-//import { Anchor } from "@mantine/core";
 import { Anchor } from "../../../components";
 import PeerRolesTable from "../components/PeerRolesTable";
 


### PR DESCRIPTION
Noting that this is just the front-end display for the create new peer roles; see task #69 for next steps
However it also includes changes so that the peer-role table will display the actual data (which will only include buddies until we can actually add new peer roles to the database)